### PR TITLE
Bump nginx from 1.16.0-alpine to 1.17.7-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.16.0-alpine
+FROM nginx:1.17.7-alpine
 
 RUN rm /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
Bumps nginx from 1.16.0-alpine to 1.17.7-alpine.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>